### PR TITLE
ci: add basic checks workflow

### DIFF
--- a/.github/workflows/basic-checks.yml
+++ b/.github/workflows/basic-checks.yml
@@ -1,0 +1,14 @@
+name: Basic checks
+
+on: [pull_request, push]
+
+jobs:
+  npm_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+      - run: npm ci
+        # Runs lint also.  Lint doesn't typecheck.
+      - run: npm run build
+      - run: npx prettier -c .


### PR DESCRIPTION
This patchset adds a basic GH workflow that checks formatting and performs a `next build` to do a lint and type-check.  It runs on PRs and pushes.