### PR TITLE
Two tiny tweaks

### DIFF
--- a/src/components/GuardBlock.tsx
+++ b/src/components/GuardBlock.tsx
@@ -3,11 +3,9 @@
 import React, { ReactNode } from 'react';
 import { redirect } from 'next/navigation';
 import { useAuth } from '@/context/AuthContext';
-import { useQuery } from '@tanstack/react-query';
 import { useHttpClient } from '@/context/HttpClientContext';
-import { getMe } from '@/api/employee';
-import { MeResponseDto } from '@/api/response/MeResponseDto';
 import { Privilege } from '@/types/privileges';
+import { useMe } from '@/hooks/use-me';
 
 interface GuardBlockProps {
   requiredPrivileges: Privilege[];
@@ -23,14 +21,7 @@ const GuardBlock: React.FC<GuardBlockProps> = ({
   const httpClient = useHttpClient();
 
   // Fetch user data (including permissions) via React Query.
-  const { data, isLoading, error } = useQuery<unknown, unknown, MeResponseDto>({
-    queryKey: ['employee', 'me'],
-    queryFn: async () => {
-      const axiosResponse = await getMe(httpClient);
-      return axiosResponse.data;
-    },
-    enabled: !auth.isLoading && auth.isLoggedIn,
-  });
+  const { data, isLoading, error } = useMe(httpClient);
 
   /*
       useEffect(() => {

--- a/src/components/ui/sidebar/app-sidebar.tsx
+++ b/src/components/ui/sidebar/app-sidebar.tsx
@@ -17,7 +17,6 @@ import { useAuth } from '@/context/AuthContext';
 import { useMe } from '@/hooks/use-me';
 import { useHttpClient } from '@/context/HttpClientContext';
 import { useQueryClient } from '@tanstack/react-query';
-import { useRouter } from 'next/navigation';
 
 const data = {
   teams: [
@@ -52,7 +51,6 @@ const data = {
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const queryClient = useQueryClient();
   const httpClient = useHttpClient();
-  const router = useRouter();
   const auth = useAuth();
   const me = useMe(httpClient);
 
@@ -62,7 +60,6 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       queryClient.invalidateQueries({
         queryKey: ['employee', 'me'],
       });
-      router.replace('/');
     }
   };
 


### PR DESCRIPTION
I noticed that the `['employee', 'me']` query is repeated, so I replaced it with a call to the `useMe` hook, and I noticed a redundant `replace('/')` that is taken care of by `GuardBlock`, so I removed that also.  This also fixes a bug where clicking log out could read to an exception being thrown in the `Router`.