### PR TITLE
add intial design for loan request form and page

### DIFF
--- a/src/api/loan.ts
+++ b/src/api/loan.ts
@@ -1,0 +1,10 @@
+import { Axios } from 'axios';
+import { NewLoanRequest } from '@/api/request/loan';
+import { LoanRequestResponseDto } from '@/api/response/loan';
+
+/**
+ * Sends a new loan request to the backend (POST /loans).
+ * Uses the NewLoanRequest DTO for the request body.
+ */
+export const requestLoan = async (client: Axios, data: NewLoanRequest) =>
+  client.post<LoanRequestResponseDto>('/loans', data);

--- a/src/api/loan.ts
+++ b/src/api/loan.ts
@@ -1,10 +1,5 @@
 import { Axios } from 'axios';
 import { NewLoanRequest } from '@/api/request/loan';
-import { LoanRequestResponseDto } from '@/api/response/loan';
 
-/**
- * Sends a new loan request to the backend (POST /loans).
- * Uses the NewLoanRequest DTO for the request body.
- */
 export const requestLoan = async (client: Axios, data: NewLoanRequest) =>
-  client.post<LoanRequestResponseDto>('/loans', data);
+  client.post<void>('/loans', data);

--- a/src/api/request/loan.ts
+++ b/src/api/request/loan.ts
@@ -1,15 +1,18 @@
+import { EmploymentStatus, InterestType, LoanType } from '@/types/loan';
+import { Currency } from '@/types/currency';
+
 /**
  * DTO for creating a new loan request.
  * Matches the POST /loans request body from Swagger.
  */
 export interface NewLoanRequest {
-  loanType: string;
-  interestType: string;
+  loanType: LoanType;
+  interestType: InterestType;
   amount: number;
-  currency: string;
+  currency: Currency;
   purposeOfLoan: string;
   monthlyIncome: number;
-  employmentStatus: string;
+  employmentStatus: EmploymentStatus;
   employmentPeriod: number;
   repaymentPeriod: number;
   contactPhone: string;

--- a/src/api/request/loan.ts
+++ b/src/api/request/loan.ts
@@ -1,0 +1,17 @@
+/**
+ * DTO for creating a new loan request.
+ * Matches the POST /loans request body from Swagger.
+ */
+export interface NewLoanRequest {
+  loanType: string;
+  interestType: string;
+  amount: number;
+  currency: string;
+  purposeOfLoan: string;
+  monthlyIncome: number;
+  employmentStatus: string;
+  employmentPeriod: number;
+  repaymentPeriod: number;
+  contactPhone: string;
+  accountNumber: string;
+}

--- a/src/api/response/loan.ts
+++ b/src/api/response/loan.ts
@@ -33,5 +33,9 @@ export interface LoanRequestDto {
   loanNumber: number;
 }
 
+export interface LoanRequestResponseDto {
+  message?: string;
+}
+
 export type LoansResponseDto = Pageable<LoanDto>;
 export type LoanRequestsResponseDto = Pageable<LoanRequestDto>;

--- a/src/api/response/loan.ts
+++ b/src/api/response/loan.ts
@@ -33,9 +33,5 @@ export interface LoanRequestDto {
   loanNumber: number;
 }
 
-export interface LoanRequestResponseDto {
-  message?: string;
-}
-
 export type LoansResponseDto = Pageable<LoanDto>;
 export type LoanRequestsResponseDto = Pageable<LoanRequestDto>;

--- a/src/app/c/loans/request/page.tsx
+++ b/src/app/c/loans/request/page.tsx
@@ -2,24 +2,16 @@
 
 import React, { useEffect, useMemo } from 'react';
 import GuardBlock from '@/components/GuardBlock';
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
 import LoanFormCard, {
   LoanFormAction,
 } from '@/components/loans/loan-form-card';
 import { useBreadcrumb } from '@/context/BreadcrumbContext';
 
-import { useQuery, useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { useHttpClient } from '@/context/HttpClientContext';
 import { toastRequestError } from '@/api/errors';
 import { requestLoan } from '@/api/loan';
 import { NewLoanRequest } from '@/api/request/loan';
-import { LoanRequestResponseDto } from '@/api/response/loan';
 import { toast } from 'sonner';
 
 import { AccountDto } from '@/api/response/account';
@@ -44,16 +36,17 @@ export default function RequestLoanPage() {
     data: accountsData = [],
     isLoading,
     error,
+    isError,
   } = useQuery<AccountDto[]>({
     queryKey: ['accounts'],
     queryFn: async () => (await getClientAccounts(client)).data,
   });
 
   React.useEffect(() => {
-    if (error) {
+    if (isError) {
       toastRequestError(error);
     }
-  }, [error]);
+  }, [isError, error]);
 
   const accounts = useMemo(() => {
     if (!accountsData) return [];
@@ -63,18 +56,14 @@ export default function RequestLoanPage() {
     }));
   }, [accountsData]);
 
-  const createLoanMutation = useMutation<
-    LoanRequestResponseDto,
-    Error,
-    NewLoanRequest
-  >({
+  const createLoanMutation = useMutation({
     mutationFn: async (data: NewLoanRequest) => {
       const response = await requestLoan(client, data);
       return response.data;
     },
-    onSuccess: (loanResponse) => {
+    onSuccess: () => {
       toast.success(
-        loanResponse.message || 'Loan request processed successfully!'
+        'Loan request processed successfully. One of our employees will get right to it!'
       );
     },
     onError: (error) => {

--- a/src/app/c/loans/request/page.tsx
+++ b/src/app/c/loans/request/page.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import GuardBlock from '@/components/GuardBlock';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import LoanForm, { LoanFormAction } from '@/components/loans/loan-form';
+import { useBreadcrumb } from '@/context/BreadcrumbContext';
+
+export default function RequestLoanPage() {
+  const { dispatch } = useBreadcrumb();
+
+  useEffect(() => {
+    dispatch({
+      type: 'SET_BREADCRUMB',
+      items: [
+        { title: 'Home', url: '/c' },
+        { title: 'Loans', url: '/c/loans' },
+        { title: 'Request' },
+      ],
+    });
+  }, [dispatch]);
+
+  function handleLoanSubmit(action: LoanFormAction) {
+    if (action.update) {
+      console.log('Updating existing loan request with data:', action.data);
+    } else {
+      console.log('Creating new loan request with data:', action.data);
+    }
+    // Adding API call later
+  }
+
+  return (
+    <GuardBlock requiredUserType="client">
+      <div className="flex justify-center items-center pt-8">
+        <Card className="w-full max-w-[900px]">
+          <CardHeader>
+            <CardTitle>Loan Request</CardTitle>
+            <CardDescription>
+              Submit a new loan request using the form below.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <LoanForm
+              isUpdate={false}
+              onSubmit={handleLoanSubmit}
+              isPending={false} // Za sada
+            />
+          </CardContent>
+        </Card>
+      </div>
+    </GuardBlock>
+  );
+}

--- a/src/app/c/loans/request/page.tsx
+++ b/src/app/c/loans/request/page.tsx
@@ -9,7 +9,9 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import LoanForm, { LoanFormAction } from '@/components/loans/loan-form';
+import LoanFormCard, {
+  LoanFormAction,
+} from '@/components/loans/loan-form-card';
 import { useBreadcrumb } from '@/context/BreadcrumbContext';
 
 export default function RequestLoanPage() {
@@ -27,13 +29,16 @@ export default function RequestLoanPage() {
   }, [dispatch]);
 
   function handleLoanSubmit(action: LoanFormAction) {
-    if (action.update) {
-      console.log('Updating existing loan request with data:', action.data);
-    } else {
-      console.log('Creating new loan request with data:', action.data);
-    }
-    // Adding API call later
+    console.log('Creating new loan request with data:', action.data);
+    // API call will be added later.
   }
+
+  // Pass a static array of accounts as a prop (in a real scenario, fetched from API)
+  const accounts = [
+    { accountNumber: '35123456789012345000', currency: 'RSD' },
+    { accountNumber: '35123456789012345001', currency: 'EUR' },
+    { accountNumber: '35123456789012345002', currency: 'RSD' },
+  ];
 
   return (
     <GuardBlock requiredUserType="client">
@@ -46,10 +51,11 @@ export default function RequestLoanPage() {
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <LoanForm
-              isUpdate={false}
+            <LoanFormCard
               onSubmit={handleLoanSubmit}
-              isPending={false} // Za sada
+              onCancel={() => {}}
+              isPending={false}
+              accounts={accounts}
             />
           </CardContent>
         </Card>

--- a/src/app/c/loans/request/page.tsx
+++ b/src/app/c/loans/request/page.tsx
@@ -90,28 +90,18 @@ export default function RequestLoanPage() {
 
   return (
     <GuardBlock requiredUserType="client">
-      <div className="flex justify-center items-center pt-8">
-        <Card className="w-full max-w-[900px]">
-          <CardHeader>
-            <CardTitle>Loan Request</CardTitle>
-            <CardDescription>
-              Submit a new loan request using the form below.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <LoanFormCard
-              onSubmit={handleLoanSubmit}
-              onCancel={() => {}}
-              isPending={isLoading}
-              accounts={accounts}
-            />
-            {error && (
-              <p className="text-red-500 mt-4">
-                Failed to load accounts. Please try again later.
-              </p>
-            )}
-          </CardContent>
-        </Card>
+      <div className={'flex justify-center py-8'}>
+        <LoanFormCard
+          onSubmit={handleLoanSubmit}
+          onCancel={() => {}}
+          isPending={isLoading}
+          accounts={accounts}
+        />
+        {error && (
+          <p className="text-red-500 mt-4">
+            Failed to load accounts. Please try again later.
+          </p>
+        )}
       </div>
     </GuardBlock>
   );

--- a/src/app/c/loans/request/page.tsx
+++ b/src/app/c/loans/request/page.tsx
@@ -82,7 +82,6 @@ export default function RequestLoanPage() {
       <div className={'flex justify-center py-8'}>
         <LoanFormCard
           onSubmit={handleLoanSubmit}
-          onCancel={() => {}}
           isPending={isLoading}
           accounts={accounts}
         />

--- a/src/app/e/loans/requests/page.tsx
+++ b/src/app/e/loans/requests/page.tsx
@@ -12,21 +12,20 @@ import { LoanRequestDto } from '@/api/response/loan';
 import { useHttpClient } from '@/context/HttpClientContext';
 import { useBreadcrumb } from '@/context/BreadcrumbContext';
 import GuardBlock from '@/components/GuardBlock';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { DataTable } from '@/components/dataTable/DataTable';
 import useTablePageParams from '@/hooks/useTablePageParams';
 import FilterBar, { FilterDefinition } from '@/components/filters/FilterBar';
 import {
-  LoanFilters,
-  searchAllLoanRequests,
   approveLoan,
+  LoanFilters,
   rejectLoan,
+  searchAllLoanRequests,
 } from '@/api/loans';
 import { loanRequestColumns } from '@/ui/dataTables/loans/loansOverviewColums';
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
-import { LoanStatus, LoanType } from '@/types/loan';
-import { ALL_LOAN_STATUSES, ALL_LOAN_TYPES } from '@/types/loan';
+import { ALL_LOAN_TYPES, LoanType } from '@/types/loan';
 
 interface LoanFilter {
   loanType?: LoanType;

--- a/src/components/loans/loan-form-card.tsx
+++ b/src/components/loans/loan-form-card.tsx
@@ -13,7 +13,6 @@ export interface LoanFormCardProps {
   defaultValues?: Partial<LoanFormValues>;
   isPending: boolean;
   onSubmit: (action: LoanFormAction) => void;
-  onCancel: () => void;
   accounts: { accountNumber: string; currency: string }[];
 }
 

--- a/src/components/loans/loan-form-card.tsx
+++ b/src/components/loans/loan-form-card.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import * as React from 'react';
+import LoanForm, {
+  LoanFormAction,
+  LoanFormValues,
+} from '@/components/loans/loan-form';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+
+export type { LoanFormAction, LoanFormValues };
+
+export interface LoanFormCardProps {
+  defaultValues?: Partial<LoanFormValues>;
+  isPending: boolean;
+  onSubmit: (action: LoanFormAction) => void;
+  onCancel: () => void;
+  accounts: { accountNumber: string; currency: string }[];
+}
+
+export default function LoanFormCard({
+  defaultValues,
+  isPending,
+  onSubmit,
+  onCancel,
+  accounts,
+}: LoanFormCardProps) {
+  return (
+    <Card className="w-full max-w-[800px]">
+      <CardHeader className="p-4">
+        <h2 className="text-2xl font-semibold">New Loan Request</h2>
+        <p className="text-sm text-muted-foreground mt-2">
+          Fill out the form below to request a new loan.
+        </p>
+      </CardHeader>
+      <CardContent>
+        <LoanForm
+          defaultValues={defaultValues}
+          onSubmit={onSubmit}
+          isPending={isPending}
+          accounts={accounts}
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/loans/loan-form-card.tsx
+++ b/src/components/loans/loan-form-card.tsx
@@ -21,7 +21,6 @@ export default function LoanFormCard({
   defaultValues,
   isPending,
   onSubmit,
-  onCancel,
   accounts,
 }: LoanFormCardProps) {
   return (

--- a/src/components/loans/loan-form-card.tsx
+++ b/src/components/loans/loan-form-card.tsx
@@ -10,14 +10,12 @@ import { Card, CardContent, CardHeader } from '@/components/ui/card';
 export type { LoanFormAction, LoanFormValues };
 
 export interface LoanFormCardProps {
-  defaultValues?: Partial<LoanFormValues>;
   isPending: boolean;
   onSubmit: (action: LoanFormAction) => void;
   accounts: { accountNumber: string; currency: string }[];
 }
 
 export default function LoanFormCard({
-  defaultValues,
   isPending,
   onSubmit,
   accounts,
@@ -32,7 +30,6 @@ export default function LoanFormCard({
       </CardHeader>
       <CardContent>
         <LoanForm
-          defaultValues={defaultValues}
           onSubmit={onSubmit}
           isPending={isPending}
           accounts={accounts}

--- a/src/components/loans/loan-form.tsx
+++ b/src/components/loans/loan-form.tsx
@@ -123,7 +123,7 @@ export default function LoanForm({
           name="loanType"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Loan Type</FormLabel>
+              <FormLabel>Loan Type <span className={'text-red-500'}>*</span></FormLabel>
               <FormControl>
                 <Select
                   onValueChange={field.onChange}
@@ -152,7 +152,7 @@ export default function LoanForm({
           name="interestType"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Interest Type</FormLabel>
+              <FormLabel>Interest Type <span className={'text-red-500'}>*</span></FormLabel>
               <FormControl>
                 <Select
                   onValueChange={field.onChange}
@@ -181,7 +181,7 @@ export default function LoanForm({
           name="amount"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Amount</FormLabel>
+              <FormLabel>Amount <span className={'text-red-500'}>*</span></FormLabel>
               <FormControl>
                 <Input
                   type="number"
@@ -205,7 +205,7 @@ export default function LoanForm({
           name="currency"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Currency</FormLabel>
+              <FormLabel>Currency <span className={'text-red-500'}>*</span></FormLabel>
               <FormControl>
                 <Select
                   onValueChange={field.onChange}
@@ -234,7 +234,7 @@ export default function LoanForm({
           name="purposeOfLoan"
           render={({ field }) => (
             <FormItem className="col-span-2">
-              <FormLabel>Purpose</FormLabel>
+              <FormLabel>Purpose <span className={'text-red-500'}>*</span></FormLabel>
               <FormControl>
                 <Input {...field} placeholder="Enter purpose" />
               </FormControl>
@@ -249,7 +249,7 @@ export default function LoanForm({
           name="monthlyIncome"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Monthly Income</FormLabel>
+              <FormLabel>Monthly Income <span className={'text-red-500'}>*</span></FormLabel>
               <FormControl>
                 <Input
                   type="number"
@@ -273,7 +273,7 @@ export default function LoanForm({
           name="employmentStatus"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Employment Status</FormLabel>
+              <FormLabel>Employment Status <span className={'text-red-500'}>*</span></FormLabel>
               <FormControl>
                 <Select
                   onValueChange={field.onChange}
@@ -302,7 +302,7 @@ export default function LoanForm({
           name="employmentPeriod"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Employment Period (years)</FormLabel>
+              <FormLabel>Employment Period (years) <span className={'text-red-500'}>*</span></FormLabel>
               <FormControl>
                 <Input
                   type="number"
@@ -326,7 +326,7 @@ export default function LoanForm({
           name="repaymentPeriod"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Repayment Period</FormLabel>
+              <FormLabel>Repayment Period <span className={'text-red-500'}>*</span></FormLabel>
               <FormControl>
                 <Select
                   onValueChange={(val) => field.onChange(Number(val))}
@@ -355,7 +355,7 @@ export default function LoanForm({
           name="contactPhone"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Contact Phone</FormLabel>
+              <FormLabel>Contact Phone <span className={'text-red-500'}>*</span></FormLabel>
               <FormControl>
                 <Input {...field} placeholder="+381..." />
               </FormControl>
@@ -370,7 +370,7 @@ export default function LoanForm({
           name="accountNumber"
           render={({ field }) => (
             <FormItem className="col-span-2">
-              <FormLabel>Account Number</FormLabel>
+              <FormLabel>Account Number <span className={'text-red-500'}>*</span></FormLabel>
               <FormControl>
                 <Select onValueChange={field.onChange} value={field.value}>
                   <SelectTrigger>

--- a/src/components/loans/loan-form.tsx
+++ b/src/components/loans/loan-form.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useForm, Controller, useWatch } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import {
   Form,
   FormControl,
@@ -13,8 +13,6 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import {
   Select,
   SelectContent,
@@ -23,7 +21,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Loader } from 'lucide-react';
-import { getDirtyValues } from '@/lib/form-utils';
+import { Button } from '@/components/ui/button';
 
 const loanTypes = [
   'CASH',
@@ -51,19 +49,19 @@ const defaultPeriods = [12, 24, 36, 48, 60, 72, 84];
 const loanFormSchema = z.object({
   loanType: z.enum(loanTypes),
   interestType: z.enum(interestTypes),
-  amount: z
+  amount: z.coerce
     .number({ invalid_type_error: 'Amount is required' })
     .min(1, 'Amount must be at least 1'),
   currency: z.enum(currencies),
   purposeOfLoan: z.string().min(1, 'Purpose is required'),
-  monthlyIncome: z
+  monthlyIncome: z.coerce
     .number({ invalid_type_error: 'Monthly income is required' })
     .min(0, 'Income cannot be negative'),
   employmentStatus: z.enum(employmentStatuses),
-  employmentPeriod: z
+  employmentPeriod: z.coerce
     .number({ invalid_type_error: 'Employment period is required' })
     .min(0, 'Employment period cannot be negative'),
-  repaymentPeriod: z
+  repaymentPeriod: z.coerce
     .number({ invalid_type_error: 'Repayment period is required' })
     .min(1, 'Repayment period must be at least 1'),
   contactPhone: z.string().min(1, 'Contact phone is required'),
@@ -72,28 +70,20 @@ const loanFormSchema = z.object({
 
 export type LoanFormValues = z.infer<typeof loanFormSchema>;
 
-export type LoanFormAction =
-  | {
-      update: true;
-      data: Partial<LoanFormValues>;
-    }
-  | {
-      update: false;
-      data: LoanFormValues;
-    };
+export type LoanFormAction = { data: LoanFormValues };
 
-interface LoanFormProps {
-  isUpdate?: boolean;
+export interface LoanFormProps {
   defaultValues?: Partial<LoanFormValues>;
-  isPending?: boolean;
+  isPending: boolean;
   onSubmit: (action: LoanFormAction) => void;
+  accounts: { accountNumber: string; currency: string }[];
 }
 
 export default function LoanForm({
-  isUpdate = false,
   defaultValues,
-  isPending = false,
+  isPending,
   onSubmit,
+  accounts,
 }: LoanFormProps) {
   const form = useForm<LoanFormValues>({
     resolver: zodResolver(loanFormSchema),
@@ -108,359 +98,315 @@ export default function LoanForm({
   const currentLoanType = useWatch({ control: form.control, name: 'loanType' });
   const currentCurrency = useWatch({ control: form.control, name: 'currency' });
 
-  const clientAccounts = React.useMemo(
-    () => [
-      { accountNumber: '35123456789012345000', currency: 'RSD' },
-      { accountNumber: '35123456789012345001', currency: 'EUR' },
-      { accountNumber: '35123456789012345002', currency: 'RSD' },
-    ],
-    []
-  );
-
+  // Use the accounts passed as a prop
   const filteredAccounts = React.useMemo(
-    () => clientAccounts.filter((acc) => acc.currency === currentCurrency),
-    [clientAccounts, currentCurrency]
+    () => accounts.filter((acc) => acc.currency === currentCurrency),
+    [accounts, currentCurrency]
   );
 
-  function _onSubmit(values: LoanFormValues) {
-    if (isUpdate) {
-      onSubmit({
-        update: true,
-        data: getDirtyValues(form.formState.dirtyFields, values),
-      });
-    } else {
-      onSubmit({ update: false, data: values });
-    }
-  }
+  const _onSubmit = (values: LoanFormValues) => {
+    onSubmit({ data: values });
+  };
 
   const availableRepaymentPeriods =
     currentLoanType === 'MORTGAGE' ? mortgagePeriods : defaultPeriods;
 
   return (
-    <div className="w-full max-w-[800px]">
-      <Card>
-        <CardHeader className="p-4">
-          <h2 className="text-2xl font-semibold">
-            {isUpdate ? 'Edit Loan Request' : 'New Loan Request'}
-          </h2>
-          <p className="text-sm text-muted-foreground mt-2">
-            {isUpdate
-              ? 'Update your existing loan request.'
-              : 'Fill out the form below to request a new loan.'}
-          </p>
-        </CardHeader>
-        <CardContent>
-          <Form {...form}>
-            <form
-              onSubmit={form.handleSubmit(_onSubmit)}
-              className="grid grid-cols-2 gap-4"
-            >
-              {/* Loan Type */}
-              <FormField
-                control={form.control}
-                name="loanType"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Loan Type</FormLabel>
-                    <FormControl>
-                      <Select
-                        onValueChange={field.onChange}
-                        defaultValue={field.value}
-                      >
-                        <SelectTrigger>
-                          <SelectValue placeholder="Select loan type" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {loanTypes.map((type) => (
-                            <SelectItem key={type} value={type}>
-                              {type}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              {/* Interest Type */}
-              <FormField
-                control={form.control}
-                name="interestType"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Interest Type</FormLabel>
-                    <FormControl>
-                      <Select
-                        onValueChange={field.onChange}
-                        defaultValue={field.value}
-                      >
-                        <SelectTrigger>
-                          <SelectValue placeholder="Select interest type" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {interestTypes.map((it) => (
-                            <SelectItem key={it} value={it}>
-                              {it}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              {/* Amount */}
-              <FormField
-                control={form.control}
-                name="amount"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Amount</FormLabel>
-                    <FormControl>
-                      <Input
-                        type="number"
-                        step="0.01"
-                        placeholder="Enter amount"
-                        onChange={(e) => {
-                          const val = e.target.value;
-                          field.onChange(val === '' ? undefined : +val);
-                        }}
-                        value={
-                          field.value === undefined ? '' : String(field.value)
-                        }
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              {/* Currency */}
-              <FormField
-                control={form.control}
-                name="currency"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Currency</FormLabel>
-                    <FormControl>
-                      <Select
-                        onValueChange={field.onChange}
-                        defaultValue={field.value}
-                      >
-                        <SelectTrigger>
-                          <SelectValue placeholder="Select currency" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {currencies.map((cur) => (
-                            <SelectItem key={cur} value={cur}>
-                              {cur}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              {/* Purpose of Loan */}
-              <FormField
-                control={form.control}
-                name="purposeOfLoan"
-                render={({ field }) => (
-                  <FormItem className="col-span-2">
-                    <FormLabel>Purpose</FormLabel>
-                    <FormControl>
-                      <Input {...field} placeholder="Enter purpose" />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              {/* Monthly Income */}
-              <FormField
-                control={form.control}
-                name="monthlyIncome"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Monthly Income</FormLabel>
-                    <FormControl>
-                      <Input
-                        type="number"
-                        step="0.01"
-                        placeholder="Enter monthly income"
-                        onChange={(e) => {
-                          const val = e.target.value;
-                          field.onChange(val === '' ? undefined : +val);
-                        }}
-                        value={
-                          field.value === undefined ? '' : String(field.value)
-                        }
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              {/* Employment Status */}
-              <FormField
-                control={form.control}
-                name="employmentStatus"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Employment Status</FormLabel>
-                    <FormControl>
-                      <Select
-                        onValueChange={field.onChange}
-                        defaultValue={field.value}
-                      >
-                        <SelectTrigger>
-                          <SelectValue placeholder="Select status" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {employmentStatuses.map((status) => (
-                            <SelectItem key={status} value={status}>
-                              {status}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              {/* Employment Period */}
-              <FormField
-                control={form.control}
-                name="employmentPeriod"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Employment Period (years)</FormLabel>
-                    <FormControl>
-                      <Input
-                        type="number"
-                        step="1"
-                        placeholder="0"
-                        onChange={(e) => {
-                          const val = e.target.value;
-                          field.onChange(val === '' ? undefined : +val);
-                        }}
-                        value={
-                          field.value === undefined ? '' : String(field.value)
-                        }
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              {/* Repayment Period */}
-              <FormField
-                control={form.control}
-                name="repaymentPeriod"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Repayment Period</FormLabel>
-                    <FormControl>
-                      <Select
-                        onValueChange={(val) => field.onChange(Number(val))}
-                        value={String(field.value || '')}
-                      >
-                        <SelectTrigger>
-                          <SelectValue placeholder="Select period" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {availableRepaymentPeriods.map((period) => (
-                            <SelectItem key={period} value={String(period)}>
-                              {period} months
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              {/* Contact Phone */}
-              <FormField
-                control={form.control}
-                name="contactPhone"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Contact Phone</FormLabel>
-                    <FormControl>
-                      <Input {...field} placeholder="+381..." />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              {/* Account Number */}
-              <FormField
-                control={form.control}
-                name="accountNumber"
-                render={({ field }) => (
-                  <FormItem className="col-span-2">
-                    <FormLabel>Account Number</FormLabel>
-                    <FormControl>
-                      <Select
-                        onValueChange={field.onChange}
-                        value={field.value}
-                      >
-                        <SelectTrigger>
-                          <SelectValue placeholder="Select account" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {filteredAccounts.length === 0 ? (
-                            <SelectItem value="">
-                              No matching accounts
-                            </SelectItem>
-                          ) : (
-                            filteredAccounts.map((acc) => (
-                              <SelectItem
-                                key={acc.accountNumber}
-                                value={acc.accountNumber}
-                              >
-                                {acc.accountNumber}
-                              </SelectItem>
-                            ))
-                          )}
-                        </SelectContent>
-                      </Select>
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              {/* Submit Button */}
-              <div className="col-span-2 flex justify-end mt-4">
-                <Button
-                  type="submit"
-                  disabled={isPending}
-                  className="flex gap-2"
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(_onSubmit)}
+        className="grid grid-cols-2 gap-4"
+      >
+        {/* Loan Type */}
+        <FormField
+          control={form.control}
+          name="loanType"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Loan Type</FormLabel>
+              <FormControl>
+                <Select
+                  onValueChange={field.onChange}
+                  defaultValue={field.value}
                 >
-                  {isPending && <Loader className="w-4 h-4 animate-spin" />}
-                  Submit
-                </Button>
-              </div>
-            </form>
-          </Form>
-        </CardContent>
-      </Card>
-    </div>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select loan type" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {loanTypes.map((type) => (
+                      <SelectItem key={type} value={type}>
+                        {type}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Interest Type */}
+        <FormField
+          control={form.control}
+          name="interestType"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Interest Type</FormLabel>
+              <FormControl>
+                <Select
+                  onValueChange={field.onChange}
+                  defaultValue={field.value}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select interest type" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {interestTypes.map((it) => (
+                      <SelectItem key={it} value={it}>
+                        {it}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Amount */}
+        <FormField
+          control={form.control}
+          name="amount"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Amount</FormLabel>
+              <FormControl>
+                <Input
+                  type="number"
+                  step="100" // Increased step to 100
+                  placeholder="Enter amount"
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    field.onChange(val === '' ? undefined : +val);
+                  }}
+                  value={field.value === undefined ? '' : String(field.value)}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Currency */}
+        <FormField
+          control={form.control}
+          name="currency"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Currency</FormLabel>
+              <FormControl>
+                <Select
+                  onValueChange={field.onChange}
+                  defaultValue={field.value}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select currency" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {currencies.map((cur) => (
+                      <SelectItem key={cur} value={cur}>
+                        {cur}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Purpose of Loan */}
+        <FormField
+          control={form.control}
+          name="purposeOfLoan"
+          render={({ field }) => (
+            <FormItem className="col-span-2">
+              <FormLabel>Purpose</FormLabel>
+              <FormControl>
+                <Input {...field} placeholder="Enter purpose" />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Monthly Income */}
+        <FormField
+          control={form.control}
+          name="monthlyIncome"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Monthly Income</FormLabel>
+              <FormControl>
+                <Input
+                  type="number"
+                  step="100" // Increased step to 100
+                  placeholder="Enter monthly income"
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    field.onChange(val === '' ? undefined : +val);
+                  }}
+                  value={field.value === undefined ? '' : String(field.value)}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Employment Status */}
+        <FormField
+          control={form.control}
+          name="employmentStatus"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Employment Status</FormLabel>
+              <FormControl>
+                <Select
+                  onValueChange={field.onChange}
+                  defaultValue={field.value}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select status" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {employmentStatuses.map((status) => (
+                      <SelectItem key={status} value={status}>
+                        {status}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Employment Period */}
+        <FormField
+          control={form.control}
+          name="employmentPeriod"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Employment Period (years)</FormLabel>
+              <FormControl>
+                <Input
+                  type="number"
+                  step="1"
+                  placeholder="0"
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    field.onChange(val === '' ? undefined : +val);
+                  }}
+                  value={field.value === undefined ? '' : String(field.value)}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Repayment Period */}
+        <FormField
+          control={form.control}
+          name="repaymentPeriod"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Repayment Period</FormLabel>
+              <FormControl>
+                <Select
+                  onValueChange={(val) => field.onChange(Number(val))}
+                  value={String(field.value || '')}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select period" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {availableRepaymentPeriods.map((period) => (
+                      <SelectItem key={period} value={String(period)}>
+                        {period} months
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Contact Phone */}
+        <FormField
+          control={form.control}
+          name="contactPhone"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Contact Phone</FormLabel>
+              <FormControl>
+                <Input {...field} placeholder="+381..." />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Account Number */}
+        <FormField
+          control={form.control}
+          name="accountNumber"
+          render={({ field }) => (
+            <FormItem className="col-span-2">
+              <FormLabel>Account Number</FormLabel>
+              <FormControl>
+                <Select onValueChange={field.onChange} value={field.value}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select account" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {filteredAccounts.length > 0 ? (
+                      filteredAccounts.map((acc) => (
+                        <SelectItem
+                          key={acc.accountNumber}
+                          value={acc.accountNumber}
+                        >
+                          {acc.accountNumber}
+                        </SelectItem>
+                      ))
+                    ) : (
+                      <div className="p-2 text-sm text-gray-500 dark:text-gray-400">
+                        No available accounts for selected currency
+                      </div>
+                    )}
+                  </SelectContent>
+                </Select>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Submit Button */}
+        <div className="col-span-2 flex justify-end mt-4">
+          <Button type="submit" disabled={isPending} className="flex gap-2">
+            {isPending && <Loader className="w-4 h-4 animate-spin" />}
+            Submit
+          </Button>
+        </div>
+      </form>
+    </Form>
   );
 }

--- a/src/components/loans/loan-form.tsx
+++ b/src/components/loans/loan-form.tsx
@@ -1,0 +1,466 @@
+'use client';
+
+import * as React from 'react';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm, Controller, useWatch } from 'react-hook-form';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Loader } from 'lucide-react';
+import { getDirtyValues } from '@/lib/form-utils';
+
+const loanTypes = [
+  'CASH',
+  'MORTGAGE',
+  'AUTO',
+  'REFINANCING',
+  'STUDENT',
+] as const;
+const interestTypes = ['FIXED', 'VARIABLE', 'COMPOUND'] as const;
+const employmentStatuses = ['PERMANENT', 'TEMPORARY', 'UNEMPLOYED'] as const;
+const currencies = [
+  'RSD',
+  'EUR',
+  'CHF',
+  'USD',
+  'GBP',
+  'JPY',
+  'CAD',
+  'AUD',
+] as const;
+
+const mortgagePeriods = [60, 120, 180, 240, 300, 360];
+const defaultPeriods = [12, 24, 36, 48, 60, 72, 84];
+
+const loanFormSchema = z.object({
+  loanType: z.enum(loanTypes),
+  interestType: z.enum(interestTypes),
+  amount: z
+    .number({ invalid_type_error: 'Amount is required' })
+    .min(1, 'Amount must be at least 1'),
+  currency: z.enum(currencies),
+  purposeOfLoan: z.string().min(1, 'Purpose is required'),
+  monthlyIncome: z
+    .number({ invalid_type_error: 'Monthly income is required' })
+    .min(0, 'Income cannot be negative'),
+  employmentStatus: z.enum(employmentStatuses),
+  employmentPeriod: z
+    .number({ invalid_type_error: 'Employment period is required' })
+    .min(0, 'Employment period cannot be negative'),
+  repaymentPeriod: z
+    .number({ invalid_type_error: 'Repayment period is required' })
+    .min(1, 'Repayment period must be at least 1'),
+  contactPhone: z.string().min(1, 'Contact phone is required'),
+  accountNumber: z.string().min(1, 'Account number is required'),
+});
+
+export type LoanFormValues = z.infer<typeof loanFormSchema>;
+
+export type LoanFormAction =
+  | {
+      update: true;
+      data: Partial<LoanFormValues>;
+    }
+  | {
+      update: false;
+      data: LoanFormValues;
+    };
+
+interface LoanFormProps {
+  isUpdate?: boolean;
+  defaultValues?: Partial<LoanFormValues>;
+  isPending?: boolean;
+  onSubmit: (action: LoanFormAction) => void;
+}
+
+export default function LoanForm({
+  isUpdate = false,
+  defaultValues,
+  isPending = false,
+  onSubmit,
+}: LoanFormProps) {
+  const form = useForm<LoanFormValues>({
+    resolver: zodResolver(loanFormSchema),
+    defaultValues: {
+      loanType: 'CASH',
+      interestType: 'FIXED',
+      currency: 'RSD',
+      ...defaultValues,
+    } as LoanFormValues,
+  });
+
+  const currentLoanType = useWatch({ control: form.control, name: 'loanType' });
+  const currentCurrency = useWatch({ control: form.control, name: 'currency' });
+
+  const clientAccounts = React.useMemo(
+    () => [
+      { accountNumber: '35123456789012345000', currency: 'RSD' },
+      { accountNumber: '35123456789012345001', currency: 'EUR' },
+      { accountNumber: '35123456789012345002', currency: 'RSD' },
+    ],
+    []
+  );
+
+  const filteredAccounts = React.useMemo(
+    () => clientAccounts.filter((acc) => acc.currency === currentCurrency),
+    [clientAccounts, currentCurrency]
+  );
+
+  function _onSubmit(values: LoanFormValues) {
+    if (isUpdate) {
+      onSubmit({
+        update: true,
+        data: getDirtyValues(form.formState.dirtyFields, values),
+      });
+    } else {
+      onSubmit({ update: false, data: values });
+    }
+  }
+
+  const availableRepaymentPeriods =
+    currentLoanType === 'MORTGAGE' ? mortgagePeriods : defaultPeriods;
+
+  return (
+    <div className="w-full max-w-[800px]">
+      <Card>
+        <CardHeader className="p-4">
+          <h2 className="text-2xl font-semibold">
+            {isUpdate ? 'Edit Loan Request' : 'New Loan Request'}
+          </h2>
+          <p className="text-sm text-muted-foreground mt-2">
+            {isUpdate
+              ? 'Update your existing loan request.'
+              : 'Fill out the form below to request a new loan.'}
+          </p>
+        </CardHeader>
+        <CardContent>
+          <Form {...form}>
+            <form
+              onSubmit={form.handleSubmit(_onSubmit)}
+              className="grid grid-cols-2 gap-4"
+            >
+              {/* Loan Type */}
+              <FormField
+                control={form.control}
+                name="loanType"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Loan Type</FormLabel>
+                    <FormControl>
+                      <Select
+                        onValueChange={field.onChange}
+                        defaultValue={field.value}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select loan type" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {loanTypes.map((type) => (
+                            <SelectItem key={type} value={type}>
+                              {type}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {/* Interest Type */}
+              <FormField
+                control={form.control}
+                name="interestType"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Interest Type</FormLabel>
+                    <FormControl>
+                      <Select
+                        onValueChange={field.onChange}
+                        defaultValue={field.value}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select interest type" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {interestTypes.map((it) => (
+                            <SelectItem key={it} value={it}>
+                              {it}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {/* Amount */}
+              <FormField
+                control={form.control}
+                name="amount"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Amount</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        step="0.01"
+                        placeholder="Enter amount"
+                        onChange={(e) => {
+                          const val = e.target.value;
+                          field.onChange(val === '' ? undefined : +val);
+                        }}
+                        value={
+                          field.value === undefined ? '' : String(field.value)
+                        }
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {/* Currency */}
+              <FormField
+                control={form.control}
+                name="currency"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Currency</FormLabel>
+                    <FormControl>
+                      <Select
+                        onValueChange={field.onChange}
+                        defaultValue={field.value}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select currency" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {currencies.map((cur) => (
+                            <SelectItem key={cur} value={cur}>
+                              {cur}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {/* Purpose of Loan */}
+              <FormField
+                control={form.control}
+                name="purposeOfLoan"
+                render={({ field }) => (
+                  <FormItem className="col-span-2">
+                    <FormLabel>Purpose</FormLabel>
+                    <FormControl>
+                      <Input {...field} placeholder="Enter purpose" />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {/* Monthly Income */}
+              <FormField
+                control={form.control}
+                name="monthlyIncome"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Monthly Income</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        step="0.01"
+                        placeholder="Enter monthly income"
+                        onChange={(e) => {
+                          const val = e.target.value;
+                          field.onChange(val === '' ? undefined : +val);
+                        }}
+                        value={
+                          field.value === undefined ? '' : String(field.value)
+                        }
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {/* Employment Status */}
+              <FormField
+                control={form.control}
+                name="employmentStatus"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Employment Status</FormLabel>
+                    <FormControl>
+                      <Select
+                        onValueChange={field.onChange}
+                        defaultValue={field.value}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select status" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {employmentStatuses.map((status) => (
+                            <SelectItem key={status} value={status}>
+                              {status}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {/* Employment Period */}
+              <FormField
+                control={form.control}
+                name="employmentPeriod"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Employment Period (years)</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        step="1"
+                        placeholder="0"
+                        onChange={(e) => {
+                          const val = e.target.value;
+                          field.onChange(val === '' ? undefined : +val);
+                        }}
+                        value={
+                          field.value === undefined ? '' : String(field.value)
+                        }
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {/* Repayment Period */}
+              <FormField
+                control={form.control}
+                name="repaymentPeriod"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Repayment Period</FormLabel>
+                    <FormControl>
+                      <Select
+                        onValueChange={(val) => field.onChange(Number(val))}
+                        value={String(field.value || '')}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select period" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {availableRepaymentPeriods.map((period) => (
+                            <SelectItem key={period} value={String(period)}>
+                              {period} months
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {/* Contact Phone */}
+              <FormField
+                control={form.control}
+                name="contactPhone"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Contact Phone</FormLabel>
+                    <FormControl>
+                      <Input {...field} placeholder="+381..." />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {/* Account Number */}
+              <FormField
+                control={form.control}
+                name="accountNumber"
+                render={({ field }) => (
+                  <FormItem className="col-span-2">
+                    <FormLabel>Account Number</FormLabel>
+                    <FormControl>
+                      <Select
+                        onValueChange={field.onChange}
+                        value={field.value}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select account" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {filteredAccounts.length === 0 ? (
+                            <SelectItem value="">
+                              No matching accounts
+                            </SelectItem>
+                          ) : (
+                            filteredAccounts.map((acc) => (
+                              <SelectItem
+                                key={acc.accountNumber}
+                                value={acc.accountNumber}
+                              >
+                                {acc.accountNumber}
+                              </SelectItem>
+                            ))
+                          )}
+                        </SelectContent>
+                      </Select>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {/* Submit Button */}
+              <div className="col-span-2 flex justify-end mt-4">
+                <Button
+                  type="submit"
+                  disabled={isPending}
+                  className="flex gap-2"
+                >
+                  {isPending && <Loader className="w-4 h-4 animate-spin" />}
+                  Submit
+                </Button>
+              </div>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/loans/loan-form.tsx
+++ b/src/components/loans/loan-form.tsx
@@ -24,7 +24,6 @@ import { Loader } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   ALL_DEFAULT_PERIODS,
-  ALL_DEFAULT_PERIODS_,
   ALL_EMPLOYMENT_STATUSES,
   ALL_EMPLOYMENT_STATUSES_,
   ALL_INTEREST_TYPES,
@@ -32,7 +31,6 @@ import {
   ALL_LOAN_TYPES,
   ALL_LOAN_TYPES_,
   ALL_MORTGAGE_PERIODS,
-  ALL_MORTGAGE_PERIODS_,
 } from '@/types/loan';
 import { currencyOptions } from '@/types/currency';
 import { SomePartials } from '@/types/utils';

--- a/src/lib/form-utils.ts
+++ b/src/lib/form-utils.ts
@@ -1,3 +1,5 @@
+import * as z from 'zod'
+
 // https://stackoverflow.com/questions/77310521/how-to-only-submit-data-change-in-react-hook-form
 // Map RHF's dirtyFields over the `data` received by `handleSubmit` and return the changed subset of that data.
 export function getDirtyValues<
@@ -21,4 +23,18 @@ export function getDirtyValues<
   }, {});
 
   return dirtyValues;
+}
+
+export function numberEnum<T extends number>(values: readonly T[]) {
+  const set = new Set<unknown>(values);
+  return (v: number, ctx: z.RefinementCtx): v is T => {
+    if (!set.has(v)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.invalid_enum_value,
+        received: v,
+        options: [...values]
+      });
+    }
+    return z.NEVER;
+  };
 }

--- a/src/lib/form-utils.ts
+++ b/src/lib/form-utils.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod'
+import * as z from 'zod';
 
 // https://stackoverflow.com/questions/77310521/how-to-only-submit-data-change-in-react-hook-form
 // Map RHF's dirtyFields over the `data` received by `handleSubmit` and return the changed subset of that data.
@@ -32,7 +32,7 @@ export function numberEnum<T extends number>(values: readonly T[]) {
       ctx.addIssue({
         code: z.ZodIssueCode.invalid_enum_value,
         received: v,
-        options: [...values]
+        options: [...values],
       });
     }
     return z.NEVER;

--- a/src/types/loan.ts
+++ b/src/types/loan.ts
@@ -24,3 +24,25 @@ export const ALL_LOAN_TYPES_ = [
 
 export type LoanType = (typeof ALL_LOAN_TYPES_)[number];
 export const ALL_LOAN_TYPES: LoanType[] = [...ALL_LOAN_TYPES_];
+
+export const ALL_EMPLOYMENT_STATUSES_ = [
+  'PERMANENT',
+  'TEMPORARY',
+  'UNEMPLOYED',
+] as const;
+
+export type EmploymentStatus = (typeof ALL_EMPLOYMENT_STATUSES_)[number];
+export const ALL_EMPLOYMENT_STATUSES: EmploymentStatus[] = [
+  ...ALL_EMPLOYMENT_STATUSES_,
+];
+
+export const ALL_MORTGAGE_PERIODS_ = [60, 120, 180, 240, 300, 360] as const;
+export const ALL_DEFAULT_PERIODS_ = [12, 24, 36, 48, 60, 72, 84] as const;
+
+export type MortgagePeriod = (typeof ALL_MORTGAGE_PERIODS_)[number];
+export type DefaultPeriod = (typeof ALL_DEFAULT_PERIODS_)[number];
+
+export const ALL_MORTGAGE_PERIODS: MortgagePeriod[] = [
+  ...ALL_MORTGAGE_PERIODS_,
+];
+export const ALL_DEFAULT_PERIODS: DefaultPeriod[] = [...ALL_DEFAULT_PERIODS_];

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -3,6 +3,12 @@ export type SomePartial<T, Members extends keyof T> = Partial<
 > &
   Omit<T, Members>;
 
+export type SomePartials<T, Members extends readonly (keyof T)[]> = Omit<
+  T,
+  Members[number]
+> &
+  Partial<Pick<T, Members[number]>>;
+
 /** Check that `value` is a `never` type.  Useful for exhaustiveness and
  * dead-code checking.
  * @param value Value that should never be present.

--- a/src/ui/sidebar/entries.ts
+++ b/src/ui/sidebar/entries.ts
@@ -63,6 +63,12 @@ const ClientGroups: SidebarGroupType[] = [
         icon: List,
         privileges: [],
       },
+      {
+        title: 'Request',
+        url: '/c/loans/request',
+        icon: Plus,
+        privileges: [],
+      },
     ],
   },
   {


### PR DESCRIPTION
Closes : #139 


This is what I had in mind for request loan form and page.  While making this I used backend's swagger and added interestType myself. `Implemented breadcrumb and updated sidebar!`

API call will be implemented once you give me thumbs up on this.

Below there is a image of a console when the submit button is clicked which displays data from form in form of request. 

Give it a go and let me know what you think.

Page is on `/c/loans/request`  

🚀 
 
![Screenshot 2025-03-11 175226](https://github.com/user-attachments/assets/c133d353-5bbf-465a-a3cb-00119e2dd827)
